### PR TITLE
Remove redundant YYLOC global declaration

### DIFF
--- a/scripts/dtc/dtc-lexer.lex.c_shipped
+++ b/scripts/dtc/dtc-lexer.lex.c_shipped
@@ -637,7 +637,7 @@ char *yytext;
 #include "srcpos.h"
 #include "dtc-parser.tab.h"
 
-YYLTYPE yylloc;
+extern YYLTYPE yylloc;
 
 /* CAUTION: this will stop working if we ever use yyless() or yyunput() */
 #define	YY_USER_ACTION \


### PR DESCRIPTION
Following https://github.com/Tomoms/android_kernel_oppo_msm8974/commit/11647f99b4de6bc460e106e876f72fc7af3e54a6

gcc 10 will default to -fno-common, which causes this error at link time:

  (.text+0x0): multiple definition of `yylloc'; dtc-lexer.lex.o (symbol from plugin):(.text+0x0): first defined here

This is because both dtc-lexer, as well as dtc-parser, define the same global symbol yyloc.
Before with -fcommon those were merged into one definition.

Marking the symbol as extern seems sufficient in contrast to the above-linked commit message.
Removing it breaks as described there breaks the build.